### PR TITLE
chore(*): Update RXJS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5364,11 +5364,11 @@
       }
     },
     "rxjs": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.3.tgz",
-      "integrity": "sha1-/IvfRk6/k4gSdI5BlniPOS/vl1Q=",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
       "requires": {
-        "symbol-observable": "1.2.0"
+        "symbol-observable": "1.0.1"
       }
     },
     "safe-buffer": {
@@ -6137,9 +6137,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
     },
     "tapable": {
       "version": "0.2.8",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
   },
   "dependencies": {
     "eventemitter3": "^2.0.3",
-    "rxjs": "~5.0.3"
+    "rxjs": "^5.5.6"
   }
 }


### PR DESCRIPTION
With this fix, miix quickstart will actually be able to miix serve without issues.

Another PR will happen for miix-cli too.