### PR TITLE
feat(navigation): Disable Navigation when Xbox Keyboard is showing

### DIFF
--- a/src/bundle/navigation.ts
+++ b/src/bundle/navigation.ts
@@ -43,11 +43,11 @@ export class Navigation extends EventEmitter {
     );
 
     rpc.expose('keyboardShowing', () => {
-      window.TVJS.Directionalnavigation.Enabled = false;
+      window.TVJS.DirectionalNavigation.enabled = false;
     });
 
     rpc.expose('keyboardHiding', () => {
-      window.TVJS.Directionalnavigation.Enabled = true;
+      window.TVJS.DirectionalNavigation.enabled = true;
     });
 
     rpc.expose('focusIn', () => {

--- a/src/participant.ts
+++ b/src/participant.ts
@@ -108,15 +108,13 @@ export class Participant extends EventEmitter {
     this.runOnRpc(rpc => {
       rpc.call('updateSettings', settings, false);
       if (window.Windows) {
-        const viewPane = window.Windows.UI.ViewManagement.InputPane.GetForCurrentView();
-
-        viewPane.on('showing', () => {
+        const viewPane = window.Windows.UI.ViewManagement.InputPane.getForCurrentView();
+        viewPane.onshowing = () => {
           rpc.call('keyboardShowing', {}, false);
-        });
-
-        viewPane.on('hiding', () => {
+        };
+        viewPane.onhiding = () => {
           rpc.call('keyboardHiding', {}, false);
-        })
+        };
       }
     });
   }


### PR DESCRIPTION
Simply disables navigation when the on screen keyboard is showing, and enables it again when closing the keyboard.