### PR TITLE
Address event ordering issues with exit

### DIFF
--- a/src/bundle/navigation.ts
+++ b/src/bundle/navigation.ts
@@ -13,6 +13,12 @@ const enum Keys {
   View = 208,
 }
 
+const enum ExitHandler {
+  Disabled,
+  Enabled,
+  EnableOnce,
+}
+
 /**
  * The Navigation class provides utilities for dealing with user requests
  * to nevigate around or away from the interactive controls.
@@ -23,7 +29,7 @@ export class Navigation {
     view: false,
   };
 
-  private handlingExit = false;
+  private handlingExit = ExitHandler.Disabled;
 
   constructor(private readonly rpc: RPC) {
     window.addEventListener(
@@ -57,17 +63,33 @@ export class Navigation {
   }
 
   /**
-   * Should be called when the integration wants to intercept an event which
-   * would otherwise cause the Interactive integration to close, such as
-   * the "X" button on the user's controller when watching on their Xbox.
-   * Calling this will cause the next press of "X" to have no effect.
+   * Should be called when the integration wants to intercept a single event
+   * which would otherwise cause the Interactive integration to close, such as
+   * the "B" button on the user's controller when watching on their Xbox.
+   * Calling this will cause the next press of "B" to have no effect.
    */
-  public preventExit(): void {
-    this.handlingExit = true;
+  public handleExit(): void {
+    this.handlingExit = ExitHandler.EnableOnce;
   }
 
+  /**
+   * Should be called when the integration wants to intercept all events which
+   * would otherwise cause the Interactive integration to close, such as
+   * the "B" button on the user's controller when watching on their Xbox.
+   * Calling this will cause the next press of "B" to have no effect.
+   */
+  public preventExit(): void {
+    this.handlingExit = ExitHandler.Enabled;
+  }
+
+  /**
+   * Should be called when the integration wants to re-enable event which
+   * would cause the Interactive integration to close, such as
+   * the "B" button on the user's controller when watching on their Xbox.
+   * Calling this will cause the next press of "B" to have no effect.
+   */
   public allowExit(): void {
-    this.handlingExit = false;
+    this.handlingExit = ExitHandler.Disabled;
   }
 
   /**
@@ -76,9 +98,15 @@ export class Navigation {
    * @param {KeyboardEvent} ev
    */
   private handleKeydown(ev: KeyboardEvent) {
-    if (this.handlingExit && ev.keyCode === Keys.GamepadB) {
+    if (this.handlingExit !== ExitHandler.Disabled && ev.keyCode === Keys.GamepadB) {
       ev.preventDefault();
       ev.stopPropagation();
+
+      if (this.handlingExit === ExitHandler.EnableOnce) {
+        setTimeout(() => {
+          this.handlingExit = ExitHandler.Disabled;
+        })
+      }
       return;
     }
 

--- a/src/bundle/navigation.ts
+++ b/src/bundle/navigation.ts
@@ -62,8 +62,12 @@ export class Navigation {
    * the "X" button on the user's controller when watching on their Xbox.
    * Calling this will cause the next press of "X" to have no effect.
    */
-  public handleExit(): void {
+  public preventExit(): void {
     this.handlingExit = true;
+  }
+
+  public allowExit(): void {
+    this.handlingExit = false;
   }
 
   /**
@@ -75,9 +79,6 @@ export class Navigation {
     if (this.handlingExit && ev.keyCode === Keys.GamepadB) {
       ev.preventDefault();
       ev.stopPropagation();
-      setTimeout(() => {
-        this.handlingExit = false;
-      });
       return;
     }
 

--- a/src/bundle/navigation.ts
+++ b/src/bundle/navigation.ts
@@ -76,7 +76,7 @@ export class Navigation {
    * Should be called when the integration wants to intercept all events which
    * would otherwise cause the Interactive integration to close, such as
    * the "B" button on the user's controller when watching on their Xbox.
-   * Calling this will cause the next press of "B" to have no effect.
+   * Calling this will prevent every press of "B" from closing the integration.
    */
   public preventExit(): void {
     this.handlingExit = ExitHandler.Enabled;
@@ -86,7 +86,7 @@ export class Navigation {
    * Should be called when the integration wants to re-enable event which
    * would cause the Interactive integration to close, such as
    * the "B" button on the user's controller when watching on their Xbox.
-   * Calling this will cause the next press of "B" to have no effect.
+   * Calling this will allow subsequent presses of "B" to close the integration.
    */
   public allowExit(): void {
     this.handlingExit = ExitHandler.Disabled;

--- a/src/participant.ts
+++ b/src/participant.ts
@@ -266,6 +266,11 @@ export class Participant extends EventEmitter {
   public on(event: 'focusOut', handler: () => void): this;
 
   /**
+   * HandleExit is sent if we want to disable exiting with gamepadB for a single input
+   */
+  public on(event: 'handleExit', handler: () => void): this;
+
+  /**
    * PreventExit is sent if we want to disable exiting with gamepadB
    */
   public on(event: 'preventExit', handler: () => void): this;

--- a/src/participant.ts
+++ b/src/participant.ts
@@ -266,9 +266,14 @@ export class Participant extends EventEmitter {
   public on(event: 'focusOut', handler: () => void): this;
 
   /**
-   * HandleExit is sent if we want to disable exiting with gamepadB
+   * PreventExit is sent if we want to disable exiting with gamepadB
    */
-  public on(event: 'handleExit', handler: () => void): this;
+  public on(event: 'preventExit', handler: () => void): this;
+
+  /**
+   * AllowExit is sent if we want to enable exiting with gamepadB
+   */
+  public on(event: 'allowExit', handler: () => void): this;
 
   /**
    * Navigate is fired when using keyboard nav


### PR DESCRIPTION
While not ideal, it seems we're getting events out of order with long presses.  Even adjusting the value after the event loop, it still gets set improperly.  This change will allow someone to set it in their project and disable it when done no longer needed.

Open to other suggestions, but with long presses nothing else seems to work.
