### PR TITLE
feat(compat): Make participant handlers more generic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mixer/cdk-std",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Standard library for Mixer Interactive controls",
   "main": "dist/bundle.min.js",
   "typings": "dist/bundle.d.ts",

--- a/src/participant.ts
+++ b/src/participant.ts
@@ -289,6 +289,7 @@ export class Participant extends EventEmitter {
     method: 'verificationChallenge',
     fn: (params: { challenge: string }) => Promise<string>,
   ): this;
+  public add(method: string, fn: (params: any) => any): this;
   public add(method: string, fn: (params: any) => any): this {
     this.runOnRpc(rpc => {
       rpc.expose(method, fn);

--- a/src/participant.ts
+++ b/src/participant.ts
@@ -220,6 +220,11 @@ export class Participant extends EventEmitter {
    */
   private controls = new ControlsState();
 
+  /**
+   * Holds the list of exposed methods via RPC
+   */
+  private rpcExposedMethods: string[] = [];
+
   constructor(private readonly frame: IInteractiveFrame, settings: ISettings) {
     super();
     this.runOnRpc(rpc => {
@@ -411,7 +416,12 @@ export class Participant extends EventEmitter {
     handler: (input: { controlID: string; kind: string; event: string }) => void,
   ): this;
 
+  public on(event: string, handler: (...args: any[]) => void): this;
   public on(event: string, handler: (...args: any[]) => void): this {
+    this.exposeRPC(event, (...params: any[]) => {
+      params.splice(0, 0, event);
+      this.emit.apply(this, params);
+    });
     super.on(event, handler);
     return this;
   }
@@ -460,7 +470,7 @@ export class Participant extends EventEmitter {
       this.frame.removeOnMessage,
     );
 
-    this.rpc.expose<{ method: string; params: any }>('sendInteractivePacket', data => {
+    this.exposeRPC<{ method: string; params: any }>('sendInteractivePacket', data => {
       this.websocket!.send(
         JSON.stringify({
           ...data,
@@ -484,7 +494,7 @@ export class Participant extends EventEmitter {
       });
     });
 
-    this.rpc.expose('controlsReady', () => {
+    this.exposeRPC('controlsReady', () => {
       if (this.state !== State.Loading) {
         return;
       }
@@ -497,35 +507,56 @@ export class Participant extends EventEmitter {
       this.emit('loaded');
     });
 
-    this.rpc.expose('maximize', (params: { maximized: boolean; message?: string }) => {
+    this.exposeRPC('maximize', (params: { maximized: boolean; message?: string }) => {
       this.emit('maximize', params.maximized, params.message);
     });
 
-    this.rpc.expose('moveVideo', (options: IVideoPositionOptions) => {
+    this.exposeRPC('moveVideo', (options: IVideoPositionOptions) => {
       this.emit('moveVideo', options);
     });
 
-    this.rpc.expose('unloading', () => {
+    this.exposeRPC('unloading', () => {
       this.emit('unload');
     });
 
-    this.rpc.expose('log', params => {
+    this.exposeRPC('log', params => {
       this.emit('log', params);
     });
 
-    this.rpc.expose('focusOut', () => {
+    this.exposeRPC('focusOut', () => {
       this.emit('focusOut');
     });
 
-    this.rpc.expose('handleExit', () => {
+    this.exposeRPC('handleExit', () => {
       this.emit('handleExit');
     });
 
-    this.rpc.expose('navigate', () => {
+    this.exposeRPC('navigate', () => {
       this.emit('navigate');
     });
 
     this.rpc.call('resendReady', {}, false);
+  }
+
+  /**
+   * Exposes an RPC event handler. If the RPC object is not yet created the
+   * method will be queued and added later.
+   * @param event The event to expose a handler for
+   * @param handler The event handler
+   */
+  private exposeRPC<T>(event: string, handler: (arg: T) => void): void;
+  private exposeRPC(event: string, handler: (...args: any[]) => void): void {
+    const register = (rpc: RPC) => {
+      if (this.rpcExposedMethods.indexOf(event) === -1) {
+        rpc.expose(event, handler);
+      }
+    };
+
+    if (this.rpc) {
+      register(this.rpc);
+    } else {
+      this.runOnRpc(register);
+    }
   }
 
   /**

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -128,18 +128,21 @@ export class RPC extends EventEmitter {
         return;
       }
 
-      // tslint:disable-next-line
-      Promise.resolve(handler(data.params)).then(result => {
-        const packet: IRPCReply<any> = {
-          type: 'reply',
-          serviceID: RPC.serviceID,
-          id: data.id,
-          result,
-        };
+      const packet: IRPCReply<any> = {
+        type: 'reply',
+        serviceID: RPC.serviceID,
+        id: data.id,
+        result: null,
+      };
 
-        this.emit('sendReply', packet);
-        this.post(packet);
-      });
+      Promise.resolve()
+        .then(() => handler(data.params))
+        .then(r => packet.result = r)
+        .catch(e => packet.error = e)
+        .then(() => {
+          this.emit('sendReply', packet);
+          this.post(packet);
+        });
     });
   }
 
@@ -284,7 +287,7 @@ export class RPC extends EventEmitter {
           type: 'reply',
           serviceID: RPC.serviceID,
           id: packet.id,
-          error: { code: 4003, message: 'Unknown method name' },
+          error: { code: 4003, message: `Unknown method name: ${packet.method}` },
           result: null,
         });
         break;

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -137,12 +137,13 @@ export class RPC extends EventEmitter {
 
       Promise.resolve()
         .then(() => handler(data.params))
-        .then(r => packet.result = r)
-        .catch(e => packet.error = e)
+        .then(r => (packet.result = r))
+        .catch(e => (packet.error = e))
         .then(() => {
           this.emit('sendReply', packet);
           this.post(packet);
-        });
+        })
+        .catch();
     });
   }
 

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -135,6 +135,7 @@ export class RPC extends EventEmitter {
         result: null,
       };
 
+      // tslint:disable-next-line:no-floating-promises
       Promise.resolve()
         .then(() => handler(data.params))
         .then(r => (packet.result = r))
@@ -142,8 +143,7 @@ export class RPC extends EventEmitter {
         .then(() => {
           this.emit('sendReply', packet);
           this.post(packet);
-        })
-        .catch();
+        });
     });
   }
 


### PR DESCRIPTION
This makes it easier to operate between versions of the CDK STD and the Mixer frontend.

Also includes a fix for some unhandled promise rejections.