### PR TITLE
[WIP] feat(participant): allow method interception

### DIFF
--- a/src/ControlState.ts
+++ b/src/ControlState.ts
@@ -1,0 +1,89 @@
+import { EventEmitter } from 'eventemitter3';
+import { IGroup, IIncomingPacket, IScene } from './interfaces';
+
+/**
+ * Internally retains data required to acquire a control's kind.
+ * @private
+ */
+export class ControlsState extends EventEmitter {
+  private scenes: {
+    [sceneID: string]: { [controlID: string]: { kind: string; cost: number } };
+  } = {};
+  private groups: { [groupID: string]: string } = {};
+  private currentGroup = 'default';
+
+  /**
+   * Handles a packet sent from the client.
+   */
+  public handleIncomingPacket({ type, method, params }: IIncomingPacket) {
+    if (type !== 'method') {
+      return;
+    }
+
+    if (method === 'onControlCreate' || method === 'onControlUpdate') {
+      this.cacheScene(params, true);
+    }
+
+    if (method === 'onSceneCreate') {
+      params.scenes.forEach((scene: IScene) => {
+        this.cacheScene(scene);
+      });
+    }
+
+    if (method === 'onSceneDelete') {
+      delete this.scenes[params.sceneID];
+    }
+
+    if (method === 'onGroupCreate' || method === 'onGroupUpdate') {
+      params.groups.forEach((group: IGroup) => {
+        this.cacheGroup(group);
+      });
+    }
+
+    if (method === 'onGroupDelete') {
+      delete this.groups[params.groupID];
+    }
+
+    if (method === 'onParticipantJoin' || method === 'onParticipantUpdate') {
+      this.currentGroup = params.participants[0].groupID;
+    }
+  }
+
+  /**
+   * Gets a control's kind by its control ID.
+   */
+  public getControlKind(controlID: string) {
+    return this.scenes[this.groups[this.currentGroup]][controlID].kind;
+  }
+
+  public getControlCost(controlID: string) {
+    return this.scenes[this.groups[this.currentGroup]][controlID].cost;
+  }
+
+  /**
+   * Caches the control kind for a scene.
+   */
+  private cacheScene(scene: IScene, isPartial = false) {
+    if (!this.scenes[scene.sceneID] || !isPartial) {
+      this.scenes[scene.sceneID] = {};
+    }
+
+    if (!scene.controls) {
+      return;
+    }
+
+    scene.controls.forEach(control => {
+      this.scenes[scene.sceneID][control.controlID] = {
+        kind: control.kind,
+        cost: control.cost,
+      };
+    });
+  }
+
+  /**
+   * Caches a group.
+   */
+  private cacheGroup(group: IGroup) {
+    this.groups[group.groupID] = group.sceneID;
+  }
+}

--- a/src/intercept.ts
+++ b/src/intercept.ts
@@ -1,0 +1,26 @@
+export type InterceptorFn = (params: any) => Promise<boolean>;
+
+/**
+ * Interceptor Manager allows for the storage of method names to interceptor functions.
+ *
+ * It is used to gate a method from being transmitted to the Interactive server.
+ *
+ * @example interceptor.intercept(params => if(params.potato) { return Promise.resolve(false); })
+ */
+export class InterceptorManager {
+  public methods: Map<string, InterceptorFn> = new Map<string, InterceptorFn>();
+
+  public add(method: string, interceptor: InterceptorFn) {
+    this.methods.set(method, interceptor);
+  }
+  public has(method: string) {
+    return this.methods.has(method);
+  }
+
+  public run(method: string, params: any): Promise<boolean> {
+    if (this.has(method)) {
+      return this.methods.get(method)!(params);
+    }
+    return Promise.resolve(true);
+  }
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,24 @@
+export interface IScene {
+  sceneID: string;
+  controls: IControl[] | null;
+}
+
+export interface IControl {
+  controlID: string;
+  kind: string;
+  cost: number;
+}
+
+export interface IGroup {
+  groupID: string;
+  sceneID: string;
+}
+
+/**
+ * Represents raw data received from the interactive server.
+ */
+export interface IIncomingPacket {
+  type: string;
+  method: string;
+  params: any;
+}


### PR DESCRIPTION
This allows us to intercept normally transparent communication on the participant side. It also caches button costs in the same way kind was cached for GA.

Planned psudocode for front-end.
```
participant.intercept('giveInput', params => {
 if(!allowlist) {
	 const cost = getCost(malm);
	 if(cost > 0) {
       // Confirm DO YOU WANT TO PAY
		return confirm...
     }
 }
return promise.resolve(true);
})
```

Builds failing because its not done, but just looking for a general review before I go much further.