### PR TITLE
Replace iframe location vs src assignment

### DIFF
--- a/src/participant.ts
+++ b/src/participant.ts
@@ -256,7 +256,8 @@ export class Participant extends EventEmitter {
     };
 
     const ws = (this.websocket = new WebSocket(appendQueryString(options.socketAddress, qs)));
-    this.frame.src = options.contentAddress;
+    // resolves issue with FireFox storing iframe address assignment in browswer history
+    this.frame.contentWindow.location!.replace(options.contentAddress);
     this.frame.addEventListener('load', this.onFrameLoad);
 
     ws.addEventListener('message', data => {

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -59,6 +59,9 @@ export function objToError(obj: { code: number; message: string; path?: string[]
  * in tests.
  */
 export interface IPostable {
+  location?: {
+    replace(address: string): void;
+  }
   postMessage(data: any, targetOrigin: string): void;
 }
 


### PR DESCRIPTION
FF does some funky behavior when assigning src and adds this into the history.  By replacing location, we avoid this behavior.